### PR TITLE
Fix build with gcc 13.1.1

### DIFF
--- a/include/zsmake.h
+++ b/include/zsmake.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <cstdint>
 
 namespace zsync2 {
     class ZSyncFileMaker {


### PR DESCRIPTION
Hello, with the update of GCC to v13.1.1 `<cstdint>` need to be added otherwise the build fail, same as https://github.com/AppImageCommunity/libappimage/pull/184