### PR TITLE
Fix zsync URL typo

### DIFF
--- a/src/legacy_http.c
+++ b/src/legacy_http.c
@@ -534,12 +534,12 @@ int range_fetch_read_http_headers(struct range_fetch *rf) {
         if (status != 206 && status != 301 && status != 302) {
             if (status >= 300 && status < 400) {
                 log_message(
-                        "\nzsync received a redirect/further action required status code: %d\nzsync specifically refuses to proceed when a server requests further action. This is because zsync makes a very large number of requests per file retrieved, and so if zsync has to perform additional actions per request, it further increases the load on the target server. The person/entity who created this zsync file should change it to point directly to a URL where the target file can be retrieved without additional actions/redirects needing to be followed.\nSee http://zsync.moria.orc.uk/server-issues",
+                        "\nzsync received a redirect/further action required status code: %d\nzsync specifically refuses to proceed when a server requests further action. This is because zsync makes a very large number of requests per file retrieved, and so if zsync has to perform additional actions per request, it further increases the load on the target server. The person/entity who created this zsync file should change it to point directly to a URL where the target file can be retrieved without additional actions/redirects needing to be followed.\nSee http://zsync.moria.org.uk/server-issues",
                         status);
             }
             else if (status == 200) {
                 log_message(
-                        "\nzsync received a data response (code %d) but this is not a partial content response\nzsync can only work with servers that support returning partial content from files. The person/entity creating this .zsync has tried to use a server that is not returning partial content. zsync cannot be used with this server.\nSee http://zsync.moria.orc.uk/server-issues",
+                        "\nzsync received a data response (code %d) but this is not a partial content response\nzsync can only work with servers that support returning partial content from files. The person/entity creating this .zsync has tried to use a server that is not returning partial content. zsync cannot be used with this server.\nSee http://zsync.moria.org.uk/server-issues",
                         status);
             }
             else {


### PR DESCRIPTION
http://zsync.moria.orc.uk/server-issues is not accessible, it should be .org.uk